### PR TITLE
Commands: DB / Extensions / Modification

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -23,6 +23,11 @@ use OpenCart\CLI\Commands\Core\ConfigCommand;
 use OpenCart\CLI\Commands\Database\InfoCommand;
 use OpenCart\CLI\Commands\Database\BackupCommand;
 use OpenCart\CLI\Commands\Database\RestoreCommand;
+use OpenCart\CLI\Commands\Extension\ListCommand as ExtensionListCommand;
+use OpenCart\CLI\Commands\Extension\InstallCommand;
+use OpenCart\CLI\Commands\Extension\EnableCommand;
+use OpenCart\CLI\Commands\Extension\DisableCommand;
+use OpenCart\CLI\Commands\Extension\ModificationListCommand;
 
 class Application extends BaseApplication
 {
@@ -59,6 +64,11 @@ class Application extends BaseApplication
         $commands[] = new InfoCommand();
         $commands[] = new BackupCommand();
         $commands[] = new RestoreCommand();
+        $commands[] = new ExtensionListCommand();
+        $commands[] = new InstallCommand();
+        $commands[] = new EnableCommand();
+        $commands[] = new DisableCommand();
+        $commands[] = new ModificationListCommand();
 
         return $commands;
     }

--- a/src/Application.php
+++ b/src/Application.php
@@ -20,6 +20,9 @@ use Symfony\Component\Console\Output\BufferedOutput;
 use OpenCart\CLI\Commands\Core\VersionCommand;
 use OpenCart\CLI\Commands\Core\CheckRequirementsCommand;
 use OpenCart\CLI\Commands\Core\ConfigCommand;
+use OpenCart\CLI\Commands\Database\InfoCommand;
+use OpenCart\CLI\Commands\Database\BackupCommand;
+use OpenCart\CLI\Commands\Database\RestoreCommand;
 
 class Application extends BaseApplication
 {
@@ -53,6 +56,9 @@ class Application extends BaseApplication
         $commands[] = new VersionCommand();
         $commands[] = new CheckRequirementsCommand();
         $commands[] = new ConfigCommand();
+        $commands[] = new InfoCommand();
+        $commands[] = new BackupCommand();
+        $commands[] = new RestoreCommand();
 
         return $commands;
     }

--- a/src/Command.php
+++ b/src/Command.php
@@ -174,7 +174,15 @@ abstract class Command extends BaseCommand
         }
 
         try {
-            $connection = new \mysqli(
+            // Set connection timeout to prevent hanging in tests
+            ini_set('default_socket_timeout', 2);
+
+            // Create mysqli instance and set timeouts before connecting
+            $connection = mysqli_init();
+            $connection->options(MYSQLI_OPT_CONNECT_TIMEOUT, 2);
+            $connection->options(MYSQLI_OPT_READ_TIMEOUT, 2);
+
+            $success = $connection->real_connect(
                 $config['db_hostname'] === 'localhost' ? '127.0.0.1' : $config['db_hostname'],
                 $config['db_username'],
                 $config['db_password'],
@@ -182,8 +190,8 @@ abstract class Command extends BaseCommand
                 $config['db_port']
             );
 
-            if ($connection->connect_error) {
-                $this->io->error("Database connection failed: " . $connection->connect_error);
+            if (!$success || $connection->connect_error) {
+                $this->io->error("Database connection failed: " . ($connection->connect_error ?: 'Connection failed'));
                 return null;
             }
 

--- a/src/Commands/Database/BackupCommand.php
+++ b/src/Commands/Database/BackupCommand.php
@@ -1,0 +1,210 @@
+<?php
+
+/**
+ * OC-CLI - OpenCart Command Line Interface
+ *
+ * @author    Custom Services Limited <info@opencartgreece.gr>
+ * @copyright 2024 Custom Services Limited
+ * @license   GPL-3.0-or-later
+ * @link      https://support.opencartgreece.gr/
+ * @link      https://github.com/Custom-Services-Limited/oc-cli
+ */
+
+namespace OpenCart\CLI\Commands\Database;
+
+use OpenCart\CLI\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+
+class BackupCommand extends Command
+{
+    protected function configure()
+    {
+        parent::configure();
+
+        $this
+            ->setName('db:backup')
+            ->setDescription('Create a database backup')
+            ->addArgument(
+                'filename',
+                InputArgument::OPTIONAL,
+                'Backup filename (auto-generated if not provided)'
+            )
+            ->addOption(
+                'compress',
+                'c',
+                InputOption::VALUE_NONE,
+                'Compress the backup using gzip'
+            )
+            ->addOption(
+                'tables',
+                't',
+                InputOption::VALUE_REQUIRED,
+                'Backup specific tables only (comma-separated)'
+            )
+            ->addOption(
+                'output-dir',
+                'o',
+                InputOption::VALUE_REQUIRED,
+                'Output directory for backup files',
+                getcwd()
+            );
+    }
+
+    protected function handle()
+    {
+        if (!$this->requireOpenCart()) {
+            return 1;
+        }
+
+        $config = $this->getOpenCartConfig();
+        if (!$config) {
+            $this->io->error('Could not read OpenCart configuration.');
+            return 1;
+        }
+
+        $connection = $this->getDatabaseConnection();
+        if (!$connection) {
+            $this->io->error('Could not connect to database.');
+            return 1;
+        }
+
+        // Generate filename if not provided
+        $filename = $this->input->getArgument('filename');
+        if (!$filename) {
+            $timestamp = date('Y-m-d_H-i-s');
+            $filename = "opencart_backup_{$timestamp}.sql";
+        }
+
+        // Add .gz extension if compressing
+        $compress = $this->input->getOption('compress');
+        if ($compress && !str_ends_with($filename, '.gz')) {
+            $filename .= '.gz';
+        }
+
+        $outputDir = $this->input->getOption('output-dir');
+        $fullPath = rtrim($outputDir, '/') . '/' . $filename;
+
+        // Ensure output directory exists
+        if (!is_dir($outputDir)) {
+            if (!mkdir($outputDir, 0755, true)) {
+                $this->io->error("Could not create output directory: {$outputDir}");
+                return 1;
+            }
+        }
+
+        $this->io->title('Creating Database Backup');
+        $this->io->text("Database: {$config['db_database']}");
+        $this->io->text("Output: {$fullPath}");
+
+        // Get tables to backup
+        $tables = $this->getTablesToBackup($connection, $config);
+        if (empty($tables)) {
+            $this->io->error('No tables found to backup.');
+            $connection->close();
+            return 1;
+        }
+
+        $this->io->text("Tables: " . count($tables));
+
+        // Create backup
+        try {
+            $this->createBackup($connection, $config, $tables, $fullPath, $compress);
+            $this->io->success("Backup created successfully: {$fullPath}");
+        } catch (\Exception $e) {
+            $this->io->error("Backup failed: " . $e->getMessage());
+            $connection->close();
+            return 1;
+        }
+
+        $connection->close();
+        return 0;
+    }
+
+    private function getTablesToBackup($connection, $config)
+    {
+        $specificTables = $this->input->getOption('tables');
+
+        if ($specificTables) {
+            return array_map('trim', explode(',', $specificTables));
+        }
+
+        // Get all tables with the OpenCart prefix
+        $prefix = $config['db_prefix'];
+        $result = $connection->query("SHOW TABLES LIKE '{$prefix}%'");
+
+        $tables = [];
+        while ($row = $result->fetch_array()) {
+            $tables[] = $row[0];
+        }
+
+        return $tables;
+    }
+
+    private function createBackup($connection, $config, $tables, $filePath, $compress)
+    {
+        // Open file handle
+        $handle = $compress ? gzopen($filePath, 'w') : fopen($filePath, 'w');
+
+        if (!$handle) {
+            throw new \Exception("Could not open file for writing: {$filePath}");
+        }
+
+        $writeFunc = $compress ? 'gzwrite' : 'fwrite';
+
+        // Write header
+        $header = "-- OpenCart Database Backup\n";
+        $header .= "-- Generated: " . date('Y-m-d H:i:s') . "\n";
+        $header .= "-- Database: {$config['db_database']}\n\n";
+        $header .= "SET FOREIGN_KEY_CHECKS=0;\n\n";
+
+        $writeFunc($handle, $header);
+
+        // Backup each table
+        foreach ($tables as $table) {
+            $this->io->text("Backing up table: {$table}");
+
+            // Get table structure
+            $createResult = $connection->query("SHOW CREATE TABLE `{$table}`");
+            if ($createResult && $createRow = $createResult->fetch_array()) {
+                $writeFunc($handle, "-- Table structure for {$table}\n");
+                $writeFunc($handle, "DROP TABLE IF EXISTS `{$table}`;\n");
+                $writeFunc($handle, $createRow[1] . ";\n\n");
+            }
+
+            // Get table data
+            $dataResult = $connection->query("SELECT * FROM `{$table}`");
+            if ($dataResult && $dataResult->num_rows > 0) {
+                $writeFunc($handle, "-- Data for table {$table}\n");
+
+                while ($row = $dataResult->fetch_assoc()) {
+                    $values = [];
+                    foreach ($row as $value) {
+                        if ($value === null) {
+                            $values[] = 'NULL';
+                        } else {
+                            $values[] = "'" . $connection->real_escape_string($value) . "'";
+                        }
+                    }
+
+                    $columns = '`' . implode('`, `', array_keys($row)) . '`';
+                    $valuesStr = implode(', ', $values);
+                    $writeFunc($handle, "INSERT INTO `{$table}` ({$columns}) VALUES ({$valuesStr});\n");
+                }
+
+                $writeFunc($handle, "\n");
+            }
+        }
+
+        // Write footer
+        $footer = "SET FOREIGN_KEY_CHECKS=1;\n";
+        $writeFunc($handle, $footer);
+
+        // Close file
+        if ($compress) {
+            gzclose($handle);
+        } else {
+            fclose($handle);
+        }
+    }
+}

--- a/src/Commands/Database/InfoCommand.php
+++ b/src/Commands/Database/InfoCommand.php
@@ -1,0 +1,125 @@
+<?php
+
+/**
+ * OC-CLI - OpenCart Command Line Interface
+ *
+ * @author    Custom Services Limited <info@opencartgreece.gr>
+ * @copyright 2024 Custom Services Limited
+ * @license   GPL-3.0-or-later
+ * @link      https://support.opencartgreece.gr/
+ * @link      https://github.com/Custom-Services-Limited/oc-cli
+ */
+
+namespace OpenCart\CLI\Commands\Database;
+
+use OpenCart\CLI\Command;
+use Symfony\Component\Console\Input\InputOption;
+
+class InfoCommand extends Command
+{
+    protected function configure()
+    {
+        parent::configure();
+
+        $this
+            ->setName('db:info')
+            ->setDescription('Display database connection information')
+            ->addOption(
+                'format',
+                'f',
+                InputOption::VALUE_REQUIRED,
+                'Output format (table, json, yaml)',
+                'table'
+            );
+    }
+
+    protected function handle()
+    {
+        if (!$this->requireOpenCart()) {
+            return 1;
+        }
+
+        $config = $this->getOpenCartConfig();
+        if (!$config) {
+            $this->io->error('Could not read OpenCart configuration.');
+            return 1;
+        }
+
+        // Test database connection
+        $connection = $this->getDatabaseConnection();
+        $connectionStatus = $connection ? 'Connected' : 'Failed';
+
+        // Get database size and table count if connected
+        $databaseSize = null;
+        $tableCount = null;
+        $serverVersion = null;
+
+        if ($connection) {
+            // Get server version
+            $serverVersion = $connection->server_info;
+
+            // Get database size
+            $result = $connection->query("
+                SELECT 
+                    ROUND(SUM(data_length + index_length) / 1024 / 1024, 2) as size_mb
+                FROM information_schema.tables 
+                WHERE table_schema = '{$config['db_database']}'
+            ");
+
+            if ($result && $row = $result->fetch_assoc()) {
+                $databaseSize = $row['size_mb'] . ' MB';
+            }
+
+            // Get table count
+            $result = $connection->query("
+                SELECT COUNT(*) as count 
+                FROM information_schema.tables 
+                WHERE table_schema = '{$config['db_database']}'
+            ");
+
+            if ($result && $row = $result->fetch_assoc()) {
+                $tableCount = $row['count'];
+            }
+
+            $connection->close();
+        }
+
+        $info = [
+            'hostname' => $config['db_hostname'],
+            'port' => $config['db_port'],
+            'username' => $config['db_username'],
+            'database' => $config['db_database'],
+            'prefix' => $config['db_prefix'],
+            'connection_status' => $connectionStatus,
+            'server_version' => $serverVersion,
+            'database_size' => $databaseSize,
+            'table_count' => $tableCount,
+        ];
+
+        $format = $this->input->getOption('format');
+
+        switch ($format) {
+            case 'json':
+                $this->io->writeln(json_encode($info, JSON_PRETTY_PRINT));
+                break;
+            case 'yaml':
+                foreach ($info as $key => $value) {
+                    $this->io->writeln($key . ': ' . ($value ?: 'null'));
+                }
+                break;
+            default:
+                $this->io->title('Database Information');
+
+                $rows = [];
+                foreach ($info as $key => $value) {
+                    $label = ucwords(str_replace('_', ' ', $key));
+                    $rows[] = [$label, $value ?: 'N/A'];
+                }
+
+                $this->io->table(['Property', 'Value'], $rows);
+                break;
+        }
+
+        return 0;
+    }
+}

--- a/src/Commands/Database/RestoreCommand.php
+++ b/src/Commands/Database/RestoreCommand.php
@@ -1,0 +1,210 @@
+<?php
+
+/**
+ * OC-CLI - OpenCart Command Line Interface
+ *
+ * @author    Custom Services Limited <info@opencartgreece.gr>
+ * @copyright 2024 Custom Services Limited
+ * @license   GPL-3.0-or-later
+ * @link      https://support.opencartgreece.gr/
+ * @link      https://github.com/Custom-Services-Limited/oc-cli
+ */
+
+namespace OpenCart\CLI\Commands\Database;
+
+use OpenCart\CLI\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+
+class RestoreCommand extends Command
+{
+    protected function configure()
+    {
+        parent::configure();
+
+        $this
+            ->setName('db:restore')
+            ->setDescription('Restore database from backup')
+            ->addArgument(
+                'filename',
+                InputArgument::REQUIRED,
+                'Backup filename to restore from'
+            )
+            ->addOption(
+                'force',
+                'f',
+                InputOption::VALUE_NONE,
+                'Skip confirmation prompt'
+            )
+            ->addOption(
+                'ignore-errors',
+                'i',
+                InputOption::VALUE_NONE,
+                'Continue execution even if errors occur'
+            );
+    }
+
+    protected function handle()
+    {
+        if (!$this->requireOpenCart()) {
+            return 1;
+        }
+
+        $config = $this->getOpenCartConfig();
+        if (!$config) {
+            $this->io->error('Could not read OpenCart configuration.');
+            return 1;
+        }
+
+        $connection = $this->getDatabaseConnection();
+        if (!$connection) {
+            $this->io->error('Could not connect to database.');
+            return 1;
+        }
+
+        $filename = $this->input->getArgument('filename');
+
+        // Check if file exists
+        if (!file_exists($filename)) {
+            $this->io->error("Backup file not found: {$filename}");
+            $connection->close();
+            return 1;
+        }
+
+        // Check if file is readable
+        if (!is_readable($filename)) {
+            $this->io->error("Backup file is not readable: {$filename}");
+            $connection->close();
+            return 1;
+        }
+
+        $this->io->title('Database Restore');
+        $this->io->text("Source: {$filename}");
+        $this->io->text("Database: {$config['db_database']}");
+
+        // Get file size for progress indication
+        $fileSize = $this->formatBytes(filesize($filename));
+        $this->io->text("File size: {$fileSize}");
+
+        // Confirm restore if not forced
+        if (!$this->input->getOption('force')) {
+            $this->io->warning('This will replace all data in the current database!');
+            if (!$this->io->confirm('Are you sure you want to continue?', false)) {
+                $this->io->text('Restore cancelled.');
+                $connection->close();
+                return 0;
+            }
+        }
+
+        // Perform restore
+        try {
+            $this->restoreFromBackup($connection, $filename);
+            $this->io->success('Database restored successfully.');
+        } catch (\Exception $e) {
+            $this->io->error("Restore failed: " . $e->getMessage());
+            $connection->close();
+            return 1;
+        }
+
+        $connection->close();
+        return 0;
+    }
+
+    private function restoreFromBackup($connection, $filename)
+    {
+        $ignoreErrors = $this->input->getOption('ignore-errors');
+
+        // Determine if file is compressed
+        $isCompressed = str_ends_with($filename, '.gz');
+
+        // Open file handle
+        $handle = $isCompressed ? gzopen($filename, 'r') : fopen($filename, 'r');
+
+        if (!$handle) {
+            throw new \Exception("Could not open backup file: {$filename}");
+        }
+
+        $readFunc = $isCompressed ? 'gzgets' : 'fgets';
+        $eofFunc = $isCompressed ? 'gzeof' : 'feof';
+
+        $this->io->text('Starting restore...');
+
+        // Disable foreign key checks
+        $connection->query('SET FOREIGN_KEY_CHECKS=0');
+
+        $lineNumber = 0;
+        $queryBuffer = '';
+        $queriesExecuted = 0;
+        $errors = [];
+
+        while (!$eofFunc($handle)) {
+            $line = $readFunc($handle);
+            $lineNumber++;
+
+            if ($line === false) {
+                break;
+            }
+
+            $line = trim($line);
+
+            // Skip empty lines and comments
+            if (empty($line) || str_starts_with($line, '--') || str_starts_with($line, '/*')) {
+                continue;
+            }
+
+            // Add line to query buffer
+            $queryBuffer .= $line;
+
+            // Check if query is complete (ends with semicolon)
+            if (str_ends_with($line, ';')) {
+                $query = trim($queryBuffer);
+                $queryBuffer = '';
+
+                if (!empty($query)) {
+                    $result = $connection->query($query);
+
+                    if ($result === false) {
+                        $error = "Line {$lineNumber}: " . $connection->error;
+                        $errors[] = $error;
+
+                        if (!$ignoreErrors) {
+                            throw new \Exception("SQL Error at line {$lineNumber}: " . $connection->error);
+                        }
+
+                        $this->io->warning("SQL Error at line {$lineNumber}: " . $connection->error);
+                    } else {
+                        $queriesExecuted++;
+
+                        // Show progress every 100 queries
+                        if ($queriesExecuted % 100 === 0) {
+                            $this->io->text("Executed {$queriesExecuted} queries...");
+                        }
+                    }
+                }
+            }
+        }
+
+        // Re-enable foreign key checks
+        $connection->query('SET FOREIGN_KEY_CHECKS=1');
+
+        // Close file handle
+        if ($isCompressed) {
+            gzclose($handle);
+        } else {
+            fclose($handle);
+        }
+
+        $this->io->text("Total queries executed: {$queriesExecuted}");
+
+        if (!empty($errors)) {
+            $this->io->warning("Encountered " . count($errors) . " errors during restore:");
+            foreach (array_slice($errors, 0, 5) as $error) {
+                $this->io->text("  - {$error}");
+            }
+
+            if (count($errors) > 5) {
+                $this->io->text("  ... and " . (count($errors) - 5) . " more errors");
+            }
+        }
+    }
+}

--- a/src/Commands/Extension/DisableCommand.php
+++ b/src/Commands/Extension/DisableCommand.php
@@ -1,0 +1,150 @@
+<?php
+
+/**
+ * OC-CLI - OpenCart Command Line Interface
+ *
+ * @author    Custom Services Limited <info@opencartgreece.gr>
+ * @copyright 2024 Custom Services Limited
+ * @license   GPL-3.0-or-later
+ * @link      https://support.opencartgreece.gr/
+ * @link      https://github.com/Custom-Services-Limited/oc-cli
+ */
+
+namespace OpenCart\CLI\Commands\Extension;
+
+use OpenCart\CLI\Command;
+use Symfony\Component\Console\Input\InputArgument;
+
+class DisableCommand extends Command
+{
+    protected function configure()
+    {
+        parent::configure();
+
+        $this
+            ->setName('extension:disable')
+            ->setDescription('Disable an extension')
+            ->addArgument(
+                'extension',
+                InputArgument::REQUIRED,
+                'Extension code or name to disable'
+            );
+    }
+
+    protected function handle()
+    {
+        if (!$this->requireOpenCart()) {
+            return 1;
+        }
+
+        $connection = $this->getDatabaseConnection();
+        if (!$connection) {
+            $this->io->error('Could not connect to database.');
+            return 1;
+        }
+
+        $extensionIdentifier = $this->input->getArgument('extension');
+
+        // Find the extension
+        $extension = $this->findExtension($connection, $extensionIdentifier);
+        if (!$extension) {
+            $this->io->error("Extension '{$extensionIdentifier}' not found.");
+            $connection->close();
+            return 1;
+        }
+
+        // Check if already disabled
+        if (!$this->isExtensionEnabled($connection, $extension)) {
+            $this->io->warning("Extension '{$extension['name']}' is already disabled.");
+            $connection->close();
+            return 0;
+        }
+
+        $this->io->title('Disabling Extension');
+        $this->io->text("Extension: {$extension['name']} ({$extension['code']})");
+
+        try {
+            if ($this->disableExtension($connection, $extension)) {
+                $this->io->success("Extension '{$extension['name']}' disabled successfully.");
+            } else {
+                $this->io->error("Failed to disable extension '{$extension['name']}'.");
+                $connection->close();
+                return 1;
+            }
+        } catch (\Exception $e) {
+            $this->io->error("Disable failed: " . $e->getMessage());
+            $connection->close();
+            return 1;
+        }
+
+        $connection->close();
+        return 0;
+    }
+
+    private function findExtension($connection, $identifier)
+    {
+        $config = $this->getOpenCartConfig();
+        $prefix = $config['db_prefix'];
+
+        // Search by code or name
+        $sql = "
+            SELECT 
+                ei.extension_install_id,
+                ei.type,
+                ei.code,
+                ei.name,
+                ei.version,
+                ei.author
+            FROM {$prefix}extension_install ei
+            WHERE ei.code = ? OR ei.name = ?
+            LIMIT 1
+        ";
+
+        $stmt = $connection->prepare($sql);
+        $stmt->bind_param('ss', $identifier, $identifier);
+        $stmt->execute();
+        $result = $stmt->get_result();
+
+        return $result->fetch_assoc();
+    }
+
+    private function isExtensionEnabled($connection, $extension)
+    {
+        $config = $this->getOpenCartConfig();
+        $prefix = $config['db_prefix'];
+
+        $sql = "
+            SELECT extension_id 
+            FROM {$prefix}extension 
+            WHERE extension_install_id = ? AND code = ?
+        ";
+
+        $stmt = $connection->prepare($sql);
+        $stmt->bind_param('is', $extension['extension_install_id'], $extension['code']);
+        $stmt->execute();
+        $result = $stmt->get_result();
+
+        return $result->fetch_assoc() !== null;
+    }
+
+    private function disableExtension($connection, $extension)
+    {
+        $config = $this->getOpenCartConfig();
+        $prefix = $config['db_prefix'];
+
+        // Remove from extension table to disable
+        $sql = "
+            DELETE FROM {$prefix}extension 
+            WHERE extension_install_id = ? AND code = ?
+        ";
+
+        $stmt = $connection->prepare($sql);
+        $stmt->bind_param(
+            'is',
+            $extension['extension_install_id'],
+            $extension['code']
+        );
+
+        return $stmt->execute();
+    }
+}

--- a/src/Commands/Extension/EnableCommand.php
+++ b/src/Commands/Extension/EnableCommand.php
@@ -1,0 +1,151 @@
+<?php
+
+/**
+ * OC-CLI - OpenCart Command Line Interface
+ *
+ * @author    Custom Services Limited <info@opencartgreece.gr>
+ * @copyright 2024 Custom Services Limited
+ * @license   GPL-3.0-or-later
+ * @link      https://support.opencartgreece.gr/
+ * @link      https://github.com/Custom-Services-Limited/oc-cli
+ */
+
+namespace OpenCart\CLI\Commands\Extension;
+
+use OpenCart\CLI\Command;
+use Symfony\Component\Console\Input\InputArgument;
+
+class EnableCommand extends Command
+{
+    protected function configure()
+    {
+        parent::configure();
+
+        $this
+            ->setName('extension:enable')
+            ->setDescription('Enable an extension')
+            ->addArgument(
+                'extension',
+                InputArgument::REQUIRED,
+                'Extension code or name to enable'
+            );
+    }
+
+    protected function handle()
+    {
+        if (!$this->requireOpenCart()) {
+            return 1;
+        }
+
+        $connection = $this->getDatabaseConnection();
+        if (!$connection) {
+            $this->io->error('Could not connect to database.');
+            return 1;
+        }
+
+        $extensionIdentifier = $this->input->getArgument('extension');
+
+        // Find the extension
+        $extension = $this->findExtension($connection, $extensionIdentifier);
+        if (!$extension) {
+            $this->io->error("Extension '{$extensionIdentifier}' not found.");
+            $connection->close();
+            return 1;
+        }
+
+        // Check if already enabled
+        if ($this->isExtensionEnabled($connection, $extension)) {
+            $this->io->warning("Extension '{$extension['name']}' is already enabled.");
+            $connection->close();
+            return 0;
+        }
+
+        $this->io->title('Enabling Extension');
+        $this->io->text("Extension: {$extension['name']} ({$extension['code']})");
+
+        try {
+            if ($this->enableExtension($connection, $extension)) {
+                $this->io->success("Extension '{$extension['name']}' enabled successfully.");
+            } else {
+                $this->io->error("Failed to enable extension '{$extension['name']}'.");
+                $connection->close();
+                return 1;
+            }
+        } catch (\Exception $e) {
+            $this->io->error("Enable failed: " . $e->getMessage());
+            $connection->close();
+            return 1;
+        }
+
+        $connection->close();
+        return 0;
+    }
+
+    private function findExtension($connection, $identifier)
+    {
+        $config = $this->getOpenCartConfig();
+        $prefix = $config['db_prefix'];
+
+        // Search by code or name
+        $sql = "
+            SELECT 
+                ei.extension_install_id,
+                ei.type,
+                ei.code,
+                ei.name,
+                ei.version,
+                ei.author
+            FROM {$prefix}extension_install ei
+            WHERE ei.code = ? OR ei.name = ?
+            LIMIT 1
+        ";
+
+        $stmt = $connection->prepare($sql);
+        $stmt->bind_param('ss', $identifier, $identifier);
+        $stmt->execute();
+        $result = $stmt->get_result();
+
+        return $result->fetch_assoc();
+    }
+
+    private function isExtensionEnabled($connection, $extension)
+    {
+        $config = $this->getOpenCartConfig();
+        $prefix = $config['db_prefix'];
+
+        $sql = "
+            SELECT extension_id 
+            FROM {$prefix}extension 
+            WHERE extension_install_id = ? AND code = ?
+        ";
+
+        $stmt = $connection->prepare($sql);
+        $stmt->bind_param('is', $extension['extension_install_id'], $extension['code']);
+        $stmt->execute();
+        $result = $stmt->get_result();
+
+        return $result->fetch_assoc() !== null;
+    }
+
+    private function enableExtension($connection, $extension)
+    {
+        $config = $this->getOpenCartConfig();
+        $prefix = $config['db_prefix'];
+
+        // Insert into extension table to enable
+        $sql = "
+            INSERT INTO {$prefix}extension (extension_install_id, type, code) 
+            VALUES (?, ?, ?)
+        ";
+
+        $stmt = $connection->prepare($sql);
+        $stmt->bind_param(
+            'iss',
+            $extension['extension_install_id'],
+            $extension['type'],
+            $extension['code']
+        );
+
+        return $stmt->execute();
+    }
+}

--- a/src/Commands/Extension/InstallCommand.php
+++ b/src/Commands/Extension/InstallCommand.php
@@ -1,0 +1,277 @@
+<?php
+
+/**
+ * OC-CLI - OpenCart Command Line Interface
+ *
+ * @author    Custom Services Limited <info@opencartgreece.gr>
+ * @copyright 2024 Custom Services Limited
+ * @license   GPL-3.0-or-later
+ * @link      https://support.opencartgreece.gr/
+ * @link      https://github.com/Custom-Services-Limited/oc-cli
+ */
+
+namespace OpenCart\CLI\Commands\Extension;
+
+use OpenCart\CLI\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+
+class InstallCommand extends Command
+{
+    protected function configure()
+    {
+        parent::configure();
+
+        $this
+            ->setName('extension:install')
+            ->setDescription('Install an extension')
+            ->addArgument(
+                'extension',
+                InputArgument::REQUIRED,
+                'Extension file path or identifier'
+            )
+            ->addOption(
+                'activate',
+                'a',
+                InputOption::VALUE_NONE,
+                'Activate extension after installation'
+            );
+    }
+
+    protected function handle()
+    {
+        if (!$this->requireOpenCart()) {
+            return 1;
+        }
+
+        $connection = $this->getDatabaseConnection();
+        if (!$connection) {
+            $this->io->error('Could not connect to database.');
+            return 1;
+        }
+
+        $extensionPath = $this->input->getArgument('extension');
+        $activate = $this->input->getOption('activate');
+
+        // Check OpenCart version for OCMOD compatibility
+        $version = $this->getOpenCartVersion();
+        if ($this->isOpenCart4($version)) {
+            $this->io->warning('Extension installation is not fully supported for OpenCart 4.');
+            $this->io->text('This feature is designed for OpenCart 3 with OCMOD support.');
+
+            if (!$this->io->confirm('Continue anyway?', false)) {
+                $connection->close();
+                return 0;
+            }
+        }
+
+        // Validate extension file
+        if (!$this->validateExtensionFile($extensionPath)) {
+            $connection->close();
+            return 1;
+        }
+
+        $this->io->title('Installing Extension');
+        $this->io->text("Extension: {$extensionPath}");
+
+        try {
+            $extensionData = $this->extractExtensionData($extensionPath);
+            $installId = $this->installExtension($connection, $extensionData);
+
+            if ($installId) {
+                $this->io->success("Extension '{$extensionData['name']}' installed successfully.");
+
+                if ($activate) {
+                    $this->io->text('Activating extension...');
+                    if ($this->activateExtension($connection, $installId, $extensionData)) {
+                        $this->io->success('Extension activated successfully.');
+                    } else {
+                        $this->io->warning('Extension installed but activation failed.');
+                    }
+                }
+            } else {
+                $this->io->error('Extension installation failed.');
+                $connection->close();
+                return 1;
+            }
+        } catch (\Exception $e) {
+            $this->io->error("Installation failed: " . $e->getMessage());
+            $connection->close();
+            return 1;
+        }
+
+        $connection->close();
+        return 0;
+    }
+
+    private function validateExtensionFile($path)
+    {
+        if (!file_exists($path)) {
+            $this->io->error("Extension file not found: {$path}");
+            return false;
+        }
+
+        if (!is_readable($path)) {
+            $this->io->error("Extension file is not readable: {$path}");
+            return false;
+        }
+
+        $allowedExtensions = ['zip', 'ocmod', 'xml'];
+        $extension = strtolower(pathinfo($path, PATHINFO_EXTENSION));
+
+        if (!in_array($extension, $allowedExtensions)) {
+            $this->io->error("Unsupported extension file type. Allowed: " . implode(', ', $allowedExtensions));
+            return false;
+        }
+
+        return true;
+    }
+
+    private function extractExtensionData($path)
+    {
+        $filename = basename($path);
+        $extension = strtolower(pathinfo($path, PATHINFO_EXTENSION));
+
+        // Basic extension data - in a real implementation, this would parse
+        // the extension file to extract metadata
+        $data = [
+            'name' => pathinfo($filename, PATHINFO_FILENAME),
+            'code' => preg_replace('/[^a-z0-9_]/', '_', strtolower(pathinfo($filename, PATHINFO_FILENAME))),
+            'type' => 'module', // Default type
+            'version' => '1.0.0',
+            'author' => 'Unknown',
+            'filename' => $filename,
+            'path' => $path
+        ];
+
+        // For OCMOD files, try to extract XML metadata
+        if ($extension === 'xml' || $extension === 'ocmod') {
+            $xmlData = $this->parseOcmodXml($path);
+            if ($xmlData) {
+                $data = array_merge($data, $xmlData);
+            }
+        }
+
+        return $data;
+    }
+
+    private function parseOcmodXml($path)
+    {
+        try {
+            $xml = simplexml_load_file($path);
+            if ($xml === false) {
+                return null;
+            }
+
+            return [
+                'name' => (string)$xml->name ?: 'Unknown Extension',
+                'code' => (string)$xml->code ?: preg_replace('/[^a-z0-9_]/', '_', strtolower((string)$xml->name)),
+                'version' => (string)$xml->version ?: '1.0.0',
+                'author' => (string)$xml->author ?: 'Unknown'
+            ];
+        } catch (\Exception $e) {
+            $this->io->warning("Could not parse OCMOD XML: " . $e->getMessage());
+            return null;
+        }
+    }
+
+    private function installExtension($connection, $data)
+    {
+        $config = $this->getOpenCartConfig();
+        $prefix = $config['db_prefix'];
+
+        // Check if extension is already installed
+        $checkSql = "SELECT extension_install_id FROM {$prefix}extension_install WHERE code = ?";
+        $stmt = $connection->prepare($checkSql);
+        $stmt->bind_param('s', $data['code']);
+        $stmt->execute();
+        $result = $stmt->get_result();
+
+        if ($result->fetch_assoc()) {
+            throw new \Exception("Extension '{$data['code']}' is already installed.");
+        }
+
+        // Insert into extension_install table
+        $sql = "
+            INSERT INTO {$prefix}extension_install 
+            (type, code, name, version, author, filename, date_added) 
+            VALUES (?, ?, ?, ?, ?, ?, NOW())
+        ";
+
+        $stmt = $connection->prepare($sql);
+        $stmt->bind_param(
+            'ssssss',
+            $data['type'],
+            $data['code'],
+            $data['name'],
+            $data['version'],
+            $data['author'],
+            $data['filename']
+        );
+
+        if ($stmt->execute()) {
+            $installId = $connection->insert_id;
+
+            // Add to extension_path table if applicable
+            $this->addExtensionPath($connection, $installId, $data);
+
+            return $installId;
+        }
+
+        return false;
+    }
+
+    private function addExtensionPath($connection, $installId, $data)
+    {
+        $config = $this->getOpenCartConfig();
+        $prefix = $config['db_prefix'];
+
+        $sql = "INSERT INTO {$prefix}extension_path (extension_install_id, path) VALUES (?, ?)";
+        $stmt = $connection->prepare($sql);
+        $stmt->bind_param('is', $installId, $data['path']);
+        $stmt->execute();
+    }
+
+    private function activateExtension($connection, $installId, $data)
+    {
+        $config = $this->getOpenCartConfig();
+        $prefix = $config['db_prefix'];
+
+        // Add to extension table to activate
+        $sql = "INSERT INTO {$prefix}extension (extension_install_id, type, code) VALUES (?, ?, ?)";
+        $stmt = $connection->prepare($sql);
+        $stmt->bind_param('iss', $installId, $data['type'], $data['code']);
+
+        return $stmt->execute();
+    }
+
+    private function getOpenCartVersion()
+    {
+        if (!$this->openCartRoot) {
+            return null;
+        }
+
+        // Try to get version from various locations
+        $versionFiles = [
+            $this->openCartRoot . '/system/startup.php',
+            $this->openCartRoot . '/admin/model/setting/setting.php',
+            $this->openCartRoot . '/index.php'
+        ];
+
+        foreach ($versionFiles as $file) {
+            if (file_exists($file)) {
+                $content = file_get_contents($file);
+                if (preg_match("/VERSION['\"]?\s*[=:]\s*['\"]([0-9\.]+)/i", $content, $matches)) {
+                    return $matches[1];
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private function isOpenCart4($version)
+    {
+        return $version && version_compare($version, '4.0.0', '>=');
+    }
+}

--- a/src/Commands/Extension/ListCommand.php
+++ b/src/Commands/Extension/ListCommand.php
@@ -1,0 +1,144 @@
+<?php
+
+/**
+ * OC-CLI - OpenCart Command Line Interface
+ *
+ * @author    Custom Services Limited <info@opencartgreece.gr>
+ * @copyright 2024 Custom Services Limited
+ * @license   GPL-3.0-or-later
+ * @link      https://support.opencartgreece.gr/
+ * @link      https://github.com/Custom-Services-Limited/oc-cli
+ */
+
+namespace OpenCart\CLI\Commands\Extension;
+
+use OpenCart\CLI\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+
+class ListCommand extends Command
+{
+    protected function configure()
+    {
+        parent::configure();
+
+        $this
+            ->setName('extension:list')
+            ->setDescription('List installed extensions')
+            ->addArgument(
+                'type',
+                InputArgument::OPTIONAL,
+                'Extension type (module, payment, shipping, etc.)'
+            )
+            ->addOption(
+                'format',
+                'f',
+                InputOption::VALUE_REQUIRED,
+                'Output format (table, json, yaml)',
+                'table'
+            );
+    }
+
+    protected function handle()
+    {
+        if (!$this->requireOpenCart()) {
+            return 1;
+        }
+
+        $connection = $this->getDatabaseConnection();
+        if (!$connection) {
+            $this->io->error('Could not connect to database.');
+            return 1;
+        }
+
+        $type = $this->input->getArgument('type');
+        $extensions = $this->getExtensions($connection, $type);
+
+        if (empty($extensions)) {
+            $message = $type
+                ? "No extensions found for type '{$type}'."
+                : 'No extensions found.';
+            $this->io->warning($message);
+            $connection->close();
+            return 0;
+        }
+
+        $this->displayExtensions($extensions);
+        $connection->close();
+        return 0;
+    }
+
+    private function getExtensions($connection, $type = null)
+    {
+        $config = $this->getOpenCartConfig();
+        $prefix = $config['db_prefix'];
+
+        $sql = "
+            SELECT 
+                e.type,
+                e.code,
+                'enabled' as status
+            FROM {$prefix}extension e
+        ";
+
+        if ($type) {
+            $sql .= " WHERE e.type = ?";
+            $stmt = $connection->prepare($sql);
+            $stmt->bind_param('s', $type);
+            $stmt->execute();
+            $result = $stmt->get_result();
+        } else {
+            $result = $connection->query($sql);
+        }
+
+        $extensions = [];
+        if ($result) {
+            while ($row = $result->fetch_assoc()) {
+                $extensions[] = [
+                    'type' => $row['type'],
+                    'code' => $row['code'],
+                    'status' => $row['status']
+                ];
+            }
+        }
+
+        return $extensions;
+    }
+
+    private function displayExtensions($extensions)
+    {
+        $format = $this->input->getOption('format');
+
+        switch ($format) {
+            case 'json':
+                $this->io->writeln(json_encode($extensions, JSON_PRETTY_PRINT));
+                break;
+            case 'yaml':
+                foreach ($extensions as $i => $extension) {
+                    $this->io->writeln("- extension_{$i}:");
+                    foreach ($extension as $key => $value) {
+                        $this->io->writeln("    {$key}: {$value}");
+                    }
+                }
+                break;
+            default:
+                $this->io->title('Installed Extensions');
+
+                $rows = [];
+                foreach ($extensions as $extension) {
+                    $statusIcon = $extension['status'] === 'enabled' ? '✓' : '✗';
+                    $rows[] = [
+                        $extension['type'],
+                        $extension['code'],
+                        $statusIcon . ' ' . ucfirst($extension['status'])
+                    ];
+                }
+
+                $this->io->table(
+                    ['Type', 'Code', 'Status'],
+                    $rows
+                );
+                break;
+        }
+    }
+}

--- a/src/Commands/Extension/ModificationListCommand.php
+++ b/src/Commands/Extension/ModificationListCommand.php
@@ -1,0 +1,141 @@
+<?php
+
+/**
+ * OC-CLI - OpenCart Command Line Interface
+ *
+ * @author    Custom Services Limited <info@opencartgreece.gr>
+ * @copyright 2024 Custom Services Limited
+ * @license   GPL-3.0-or-later
+ * @link      https://support.opencartgreece.gr/
+ * @link      https://github.com/Custom-Services-Limited/oc-cli
+ */
+
+namespace OpenCart\CLI\Commands\Extension;
+
+use OpenCart\CLI\Command;
+use Symfony\Component\Console\Input\InputOption;
+
+class ModificationListCommand extends Command
+{
+    protected function configure()
+    {
+        parent::configure();
+
+        $this
+            ->setName('modification:list')
+            ->setDescription('List installed modifications')
+            ->addOption(
+                'format',
+                'f',
+                InputOption::VALUE_REQUIRED,
+                'Output format (table, json, yaml)',
+                'table'
+            );
+    }
+
+    protected function handle()
+    {
+        if (!$this->requireOpenCart()) {
+            return 1;
+        }
+
+        $connection = $this->getDatabaseConnection();
+        if (!$connection) {
+            $this->io->error('Could not connect to database.');
+            return 1;
+        }
+
+        $modifications = $this->getModifications($connection);
+
+        if (empty($modifications)) {
+            $this->io->warning('No modifications found.');
+            $connection->close();
+            return 0;
+        }
+
+        $this->displayModifications($modifications);
+        $connection->close();
+        return 0;
+    }
+
+    private function getModifications($connection)
+    {
+        $config = $this->getOpenCartConfig();
+        $prefix = $config['db_prefix'];
+
+        $sql = "
+            SELECT 
+                modification_id,
+                name,
+                code,
+                author,
+                version,
+                link,
+                status,
+                date_added
+            FROM {$prefix}modification
+            ORDER BY name ASC
+        ";
+
+        $result = $connection->query($sql);
+
+        $modifications = [];
+        if ($result) {
+            while ($row = $result->fetch_assoc()) {
+                $modifications[] = [
+                    'id' => $row['modification_id'],
+                    'name' => $row['name'],
+                    'code' => $row['code'],
+                    'author' => $row['author'],
+                    'version' => $row['version'],
+                    'link' => $row['link'],
+                    'status' => $row['status'] ? 'enabled' : 'disabled',
+                    'date_added' => $row['date_added']
+                ];
+            }
+        }
+
+        return $modifications;
+    }
+
+    private function displayModifications($modifications)
+    {
+        $format = $this->input->getOption('format');
+
+        switch ($format) {
+            case 'json':
+                $this->io->writeln(json_encode($modifications, JSON_PRETTY_PRINT));
+                break;
+            case 'yaml':
+                foreach ($modifications as $i => $modification) {
+                    $this->io->writeln("- modification_{$i}:");
+                    foreach ($modification as $key => $value) {
+                        $this->io->writeln("    {$key}: {$value}");
+                    }
+                }
+                break;
+            default:
+                $this->io->title('Installed Modifications');
+
+                $rows = [];
+                foreach ($modifications as $modification) {
+                    $statusIcon = $modification['status'] === 'enabled' ? '✓' : '✗';
+                    $rows[] = [
+                        $modification['id'],
+                        $modification['name'],
+                        $modification['code'],
+                        $modification['author'],
+                        $modification['version'],
+                        $statusIcon . ' ' . ucfirst($modification['status']),
+                        $modification['date_added']
+                    ];
+                }
+
+                $this->io->table(
+                    ['ID', 'Name', 'Code', 'Author', 'Version', 'Status', 'Date Added'],
+                    $rows
+                );
+                break;
+        }
+    }
+}

--- a/tests/Integration/DatabaseCommandsTest.php
+++ b/tests/Integration/DatabaseCommandsTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace OpenCart\CLI\Tests\Integration;
+
+use PHPUnit\Framework\TestCase;
+use OpenCart\CLI\Application;
+
+class DatabaseCommandsTest extends TestCase
+{
+    private $application;
+
+    protected function setUp(): void
+    {
+        $this->application = new Application();
+    }
+
+    public function testDatabaseCommandsAreRegistered()
+    {
+        $commands = $this->application->all();
+
+        $this->assertArrayHasKey('db:info', $commands);
+        $this->assertArrayHasKey('db:backup', $commands);
+        $this->assertArrayHasKey('db:restore', $commands);
+    }
+
+    public function testDatabaseCommandsHaveCorrectNames()
+    {
+        $dbInfo = $this->application->find('db:info');
+        $dbBackup = $this->application->find('db:backup');
+        $dbRestore = $this->application->find('db:restore');
+
+        $this->assertEquals('db:info', $dbInfo->getName());
+        $this->assertEquals('db:backup', $dbBackup->getName());
+        $this->assertEquals('db:restore', $dbRestore->getName());
+    }
+
+    public function testDatabaseCommandsHaveCorrectDescriptions()
+    {
+        $dbInfo = $this->application->find('db:info');
+        $dbBackup = $this->application->find('db:backup');
+        $dbRestore = $this->application->find('db:restore');
+
+        $this->assertEquals('Display database connection information', $dbInfo->getDescription());
+        $this->assertEquals('Create a database backup', $dbBackup->getDescription());
+        $this->assertEquals('Restore database from backup', $dbRestore->getDescription());
+    }
+
+    public function testAllDatabaseCommandsHaveOpenCartRootOption()
+    {
+        $commands = ['db:info', 'db:backup', 'db:restore'];
+
+        foreach ($commands as $commandName) {
+            $command = $this->application->find($commandName);
+            $definition = $command->getDefinition();
+
+            $this->assertTrue(
+                $definition->hasOption('opencart-root'),
+                "Command {$commandName} should have --opencart-root option"
+            );
+        }
+    }
+}

--- a/tests/Integration/ExtensionCommandsTest.php
+++ b/tests/Integration/ExtensionCommandsTest.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace OpenCart\CLI\Tests\Integration;
+
+use PHPUnit\Framework\TestCase;
+use OpenCart\CLI\Application;
+
+class ExtensionCommandsTest extends TestCase
+{
+    private $application;
+
+    protected function setUp(): void
+    {
+        $this->application = new Application();
+    }
+
+    public function testExtensionCommandsAreRegistered()
+    {
+        $commands = $this->application->all();
+
+        $this->assertArrayHasKey('extension:list', $commands);
+        $this->assertArrayHasKey('extension:install', $commands);
+        $this->assertArrayHasKey('extension:enable', $commands);
+        $this->assertArrayHasKey('extension:disable', $commands);
+        $this->assertArrayHasKey('modification:list', $commands);
+    }
+
+    public function testExtensionCommandsHaveCorrectNames()
+    {
+        $extensionList = $this->application->find('extension:list');
+        $extensionInstall = $this->application->find('extension:install');
+        $extensionEnable = $this->application->find('extension:enable');
+        $extensionDisable = $this->application->find('extension:disable');
+        $modificationList = $this->application->find('modification:list');
+
+        $this->assertEquals('extension:list', $extensionList->getName());
+        $this->assertEquals('extension:install', $extensionInstall->getName());
+        $this->assertEquals('extension:enable', $extensionEnable->getName());
+        $this->assertEquals('extension:disable', $extensionDisable->getName());
+        $this->assertEquals('modification:list', $modificationList->getName());
+    }
+
+    public function testExtensionCommandsHaveCorrectDescriptions()
+    {
+        $extensionList = $this->application->find('extension:list');
+        $extensionInstall = $this->application->find('extension:install');
+        $extensionEnable = $this->application->find('extension:enable');
+        $extensionDisable = $this->application->find('extension:disable');
+        $modificationList = $this->application->find('modification:list');
+
+        $this->assertEquals('List installed extensions', $extensionList->getDescription());
+        $this->assertEquals('Install an extension', $extensionInstall->getDescription());
+        $this->assertEquals('Enable an extension', $extensionEnable->getDescription());
+        $this->assertEquals('Disable an extension', $extensionDisable->getDescription());
+        $this->assertEquals('List installed modifications', $modificationList->getDescription());
+    }
+
+    public function testAllExtensionCommandsHaveOpenCartRootOption()
+    {
+        $commands = [
+            'extension:list', 'extension:install', 'extension:enable',
+            'extension:disable', 'modification:list'
+        ];
+
+        foreach ($commands as $commandName) {
+            $command = $this->application->find($commandName);
+            $definition = $command->getDefinition();
+
+            $this->assertTrue(
+                $definition->hasOption('opencart-root'),
+                "Command {$commandName} should have --opencart-root option"
+            );
+        }
+    }
+
+    public function testExtensionListCommandHasFormatOption()
+    {
+        $command = $this->application->find('extension:list');
+        $definition = $command->getDefinition();
+
+        $this->assertTrue($definition->hasOption('format'));
+        $formatOption = $definition->getOption('format');
+        $this->assertEquals('table', $formatOption->getDefault());
+    }
+
+    public function testModificationListCommandHasFormatOption()
+    {
+        $command = $this->application->find('modification:list');
+        $definition = $command->getDefinition();
+
+        $this->assertTrue($definition->hasOption('format'));
+        $formatOption = $definition->getOption('format');
+        $this->assertEquals('table', $formatOption->getDefault());
+    }
+
+    public function testExtensionInstallCommandHasActivateOption()
+    {
+        $command = $this->application->find('extension:install');
+        $definition = $command->getDefinition();
+
+        $this->assertTrue($definition->hasOption('activate'));
+        $activateOption = $definition->getOption('activate');
+        $this->assertEquals('a', $activateOption->getShortcut());
+    }
+
+    public function testExtensionCommandsHaveRequiredArguments()
+    {
+        // extension:install, extension:enable, extension:disable should have required extension argument
+        $commandsWithRequiredArgs = ['extension:install', 'extension:enable', 'extension:disable'];
+
+        foreach ($commandsWithRequiredArgs as $commandName) {
+            $command = $this->application->find($commandName);
+            $definition = $command->getDefinition();
+
+            $this->assertTrue($definition->hasArgument('extension'));
+            $extensionArg = $definition->getArgument('extension');
+            $this->assertTrue($extensionArg->isRequired());
+        }
+    }
+
+    public function testExtensionListCommandHasOptionalTypeArgument()
+    {
+        $command = $this->application->find('extension:list');
+        $definition = $command->getDefinition();
+
+        $this->assertTrue($definition->hasArgument('type'));
+        $typeArg = $definition->getArgument('type');
+        $this->assertFalse($typeArg->isRequired());
+    }
+}

--- a/tests/Unit/BackupCommandTest.php
+++ b/tests/Unit/BackupCommandTest.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace OpenCart\CLI\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use OpenCart\CLI\Commands\Database\BackupCommand;
+use OpenCart\CLI\Application;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class BackupCommandTest extends TestCase
+{
+    private $command;
+    private $application;
+
+    protected function setUp(): void
+    {
+        $this->application = new Application();
+        $this->command = new BackupCommand();
+        $this->command->setApplication($this->application);
+    }
+
+    public function testBackupCommandName()
+    {
+        $this->assertEquals('db:backup', $this->command->getName());
+    }
+
+    public function testBackupCommandDescription()
+    {
+        $this->assertEquals('Create a database backup', $this->command->getDescription());
+    }
+
+    public function testBackupCommandArguments()
+    {
+        $definition = $this->command->getDefinition();
+
+        $this->assertTrue($definition->hasArgument('filename'));
+
+        $filenameArg = $definition->getArgument('filename');
+        $this->assertFalse($filenameArg->isRequired());
+    }
+
+    public function testBackupCommandOptions()
+    {
+        $definition = $this->command->getDefinition();
+
+        $this->assertTrue($definition->hasOption('compress'));
+        $this->assertTrue($definition->hasOption('tables'));
+        $this->assertTrue($definition->hasOption('output-dir'));
+        $this->assertTrue($definition->hasOption('opencart-root'));
+
+        $compressOption = $definition->getOption('compress');
+        $this->assertEquals('c', $compressOption->getShortcut());
+
+        $tablesOption = $definition->getOption('tables');
+        $this->assertEquals('t', $tablesOption->getShortcut());
+
+        $outputDirOption = $definition->getOption('output-dir');
+        $this->assertEquals('o', $outputDirOption->getShortcut());
+        $this->assertEquals(getcwd(), $outputDirOption->getDefault());
+    }
+
+    public function testBackupCommandWithoutOpenCart()
+    {
+        $input = new ArrayInput([]);
+        $output = new BufferedOutput();
+
+        $result = $this->command->run($input, $output);
+
+        $this->assertEquals(1, $result);
+        $this->assertStringContainsString('OpenCart installation', $output->fetch());
+    }
+
+    public function testBackupCommandWithInvalidOpenCartRoot()
+    {
+        $input = new ArrayInput(['--opencart-root' => '/nonexistent/path']);
+        $output = new BufferedOutput();
+
+        $result = $this->command->run($input, $output);
+
+        $this->assertEquals(1, $result);
+        $this->assertStringContainsString('OpenCart installation', $output->fetch());
+    }
+
+    public function testBackupCommandWithFilename()
+    {
+        $input = new ArrayInput(['filename' => 'test-backup.sql']);
+        $output = new BufferedOutput();
+
+        $result = $this->command->run($input, $output);
+
+        // Should fail due to no OpenCart but test argument parsing
+        $this->assertEquals(1, $result);
+    }
+
+    public function testBackupCommandWithCompressOption()
+    {
+        $input = new ArrayInput(['--compress' => true]);
+        $output = new BufferedOutput();
+
+        $result = $this->command->run($input, $output);
+
+        // Should fail due to no OpenCart but test option parsing
+        $this->assertEquals(1, $result);
+    }
+
+    public function testBackupCommandWithTablesOption()
+    {
+        $input = new ArrayInput(['--tables' => 'oc_product,oc_category']);
+        $output = new BufferedOutput();
+
+        $result = $this->command->run($input, $output);
+
+        // Should fail due to no OpenCart but test option parsing
+        $this->assertEquals(1, $result);
+    }
+
+    public function testBackupCommandWithOutputDirOption()
+    {
+        $input = new ArrayInput(['--output-dir' => '/tmp']);
+        $output = new BufferedOutput();
+
+        $result = $this->command->run($input, $output);
+
+        // Should fail due to no OpenCart but test option parsing
+        $this->assertEquals(1, $result);
+    }
+
+    public function testBackupCommandAllOptionsAndArguments()
+    {
+        $input = new ArrayInput([
+            'filename' => 'custom-backup.sql',
+            '--compress' => true,
+            '--tables' => 'oc_product',
+            '--output-dir' => '/tmp'
+        ]);
+        $output = new BufferedOutput();
+
+        $result = $this->command->run($input, $output);
+
+        // Should fail due to no OpenCart but test all options parsing
+        $this->assertEquals(1, $result);
+    }
+
+    public function testBackupCommandHelpText()
+    {
+        $help = $this->command->getHelp();
+        $this->assertIsString($help);
+    }
+
+    public function testBackupCommandDefinition()
+    {
+        $definition = $this->command->getDefinition();
+        $options = $definition->getOptions();
+        $arguments = $definition->getArguments();
+
+        $this->assertArrayHasKey('compress', $options);
+        $this->assertArrayHasKey('tables', $options);
+        $this->assertArrayHasKey('output-dir', $options);
+        $this->assertArrayHasKey('opencart-root', $options);
+        $this->assertArrayHasKey('filename', $arguments);
+    }
+
+    public function testBackupCommandDefaultValues()
+    {
+        $definition = $this->command->getDefinition();
+
+        $outputDirOption = $definition->getOption('output-dir');
+        $this->assertEquals(getcwd(), $outputDirOption->getDefault());
+
+        $filenameArg = $definition->getArgument('filename');
+        $this->assertNull($filenameArg->getDefault());
+    }
+}

--- a/tests/Unit/ExtensionDisableCommandTest.php
+++ b/tests/Unit/ExtensionDisableCommandTest.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace OpenCart\CLI\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use OpenCart\CLI\Commands\Extension\DisableCommand;
+use OpenCart\CLI\Application;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class ExtensionDisableCommandTest extends TestCase
+{
+    private $command;
+    private $application;
+
+    protected function setUp(): void
+    {
+        $this->application = new Application();
+        $this->command = new DisableCommand();
+        $this->command->setApplication($this->application);
+    }
+
+    public function testExtensionDisableCommandName()
+    {
+        $this->assertEquals('extension:disable', $this->command->getName());
+    }
+
+    public function testExtensionDisableCommandDescription()
+    {
+        $this->assertEquals('Disable an extension', $this->command->getDescription());
+    }
+
+    public function testExtensionDisableCommandArguments()
+    {
+        $definition = $this->command->getDefinition();
+
+        $this->assertTrue($definition->hasArgument('extension'));
+
+        $extensionArg = $definition->getArgument('extension');
+        $this->assertTrue($extensionArg->isRequired());
+    }
+
+    public function testExtensionDisableCommandOptions()
+    {
+        $definition = $this->command->getDefinition();
+
+        $this->assertTrue($definition->hasOption('opencart-root'));
+    }
+
+    public function testExtensionDisableCommandWithoutOpenCart()
+    {
+        $input = new ArrayInput(['extension' => 'test_module']);
+        $output = new BufferedOutput();
+
+        $result = $this->command->run($input, $output);
+
+        $this->assertEquals(1, $result);
+        $this->assertStringContainsString('OpenCart installation', $output->fetch());
+    }
+
+    public function testExtensionDisableCommandWithInvalidOpenCartRoot()
+    {
+        $input = new ArrayInput([
+            'extension' => 'test_module',
+            '--opencart-root' => '/nonexistent/path'
+        ]);
+        $output = new BufferedOutput();
+
+        $result = $this->command->run($input, $output);
+
+        $this->assertEquals(1, $result);
+        $this->assertStringContainsString('OpenCart installation', $output->fetch());
+    }
+
+    public function testExtensionDisableCommandWithExtensionCode()
+    {
+        $input = new ArrayInput(['extension' => 'payment_paypal']);
+        $output = new BufferedOutput();
+
+        $result = $this->command->run($input, $output);
+
+        // Should fail due to no OpenCart but test argument parsing
+        $this->assertEquals(1, $result);
+    }
+
+    public function testExtensionDisableCommandWithExtensionName()
+    {
+        $input = new ArrayInput(['extension' => 'PayPal Payment']);
+        $output = new BufferedOutput();
+
+        $result = $this->command->run($input, $output);
+
+        // Should fail due to no OpenCart but test argument parsing
+        $this->assertEquals(1, $result);
+    }
+
+    public function testExtensionDisableCommandHelpText()
+    {
+        $help = $this->command->getHelp();
+        $this->assertIsString($help);
+    }
+
+    public function testExtensionDisableCommandDefinition()
+    {
+        $definition = $this->command->getDefinition();
+        $options = $definition->getOptions();
+        $arguments = $definition->getArguments();
+
+        $this->assertArrayHasKey('opencart-root', $options);
+        $this->assertArrayHasKey('extension', $arguments);
+    }
+
+    public function testExtensionDisableCommandRequiredArgument()
+    {
+        $definition = $this->command->getDefinition();
+        $extensionArg = $definition->getArgument('extension');
+
+        $this->assertTrue($extensionArg->isRequired());
+        $this->assertEquals('Extension code or name to disable', $extensionArg->getDescription());
+    }
+
+    public function testExtensionDisableCommandArgumentValidation()
+    {
+        $definition = $this->command->getDefinition();
+        $arguments = $definition->getArguments();
+
+        $this->assertCount(1, $arguments);
+        $this->assertArrayHasKey('extension', $arguments);
+    }
+
+    public function testExtensionDisableCommandOptionsCount()
+    {
+        $definition = $this->command->getDefinition();
+        $options = $definition->getOptions();
+
+        // Should have at least opencart-root option plus base options
+        $this->assertGreaterThanOrEqual(1, count($options));
+    }
+
+    public function testExtensionDisableCommandAllArguments()
+    {
+        $definition = $this->command->getDefinition();
+        $options = $definition->getOptions();
+
+        $optionNames = array_keys($options);
+        $this->assertContains('opencart-root', $optionNames);
+    }
+}

--- a/tests/Unit/ExtensionEnableCommandTest.php
+++ b/tests/Unit/ExtensionEnableCommandTest.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace OpenCart\CLI\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use OpenCart\CLI\Commands\Extension\EnableCommand;
+use OpenCart\CLI\Application;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class ExtensionEnableCommandTest extends TestCase
+{
+    private $command;
+    private $application;
+
+    protected function setUp(): void
+    {
+        $this->application = new Application();
+        $this->command = new EnableCommand();
+        $this->command->setApplication($this->application);
+    }
+
+    public function testExtensionEnableCommandName()
+    {
+        $this->assertEquals('extension:enable', $this->command->getName());
+    }
+
+    public function testExtensionEnableCommandDescription()
+    {
+        $this->assertEquals('Enable an extension', $this->command->getDescription());
+    }
+
+    public function testExtensionEnableCommandArguments()
+    {
+        $definition = $this->command->getDefinition();
+
+        $this->assertTrue($definition->hasArgument('extension'));
+
+        $extensionArg = $definition->getArgument('extension');
+        $this->assertTrue($extensionArg->isRequired());
+    }
+
+    public function testExtensionEnableCommandOptions()
+    {
+        $definition = $this->command->getDefinition();
+
+        $this->assertTrue($definition->hasOption('opencart-root'));
+    }
+
+    public function testExtensionEnableCommandWithoutOpenCart()
+    {
+        $input = new ArrayInput(['extension' => 'test_module']);
+        $output = new BufferedOutput();
+
+        $result = $this->command->run($input, $output);
+
+        $this->assertEquals(1, $result);
+        $this->assertStringContainsString('OpenCart installation', $output->fetch());
+    }
+
+    public function testExtensionEnableCommandWithInvalidOpenCartRoot()
+    {
+        $input = new ArrayInput([
+            'extension' => 'test_module',
+            '--opencart-root' => '/nonexistent/path'
+        ]);
+        $output = new BufferedOutput();
+
+        $result = $this->command->run($input, $output);
+
+        $this->assertEquals(1, $result);
+        $this->assertStringContainsString('OpenCart installation', $output->fetch());
+    }
+
+    public function testExtensionEnableCommandWithExtensionCode()
+    {
+        $input = new ArrayInput(['extension' => 'payment_paypal']);
+        $output = new BufferedOutput();
+
+        $result = $this->command->run($input, $output);
+
+        // Should fail due to no OpenCart but test argument parsing
+        $this->assertEquals(1, $result);
+    }
+
+    public function testExtensionEnableCommandWithExtensionName()
+    {
+        $input = new ArrayInput(['extension' => 'PayPal Payment']);
+        $output = new BufferedOutput();
+
+        $result = $this->command->run($input, $output);
+
+        // Should fail due to no OpenCart but test argument parsing
+        $this->assertEquals(1, $result);
+    }
+
+    public function testExtensionEnableCommandHelpText()
+    {
+        $help = $this->command->getHelp();
+        $this->assertIsString($help);
+    }
+
+    public function testExtensionEnableCommandDefinition()
+    {
+        $definition = $this->command->getDefinition();
+        $options = $definition->getOptions();
+        $arguments = $definition->getArguments();
+
+        $this->assertArrayHasKey('opencart-root', $options);
+        $this->assertArrayHasKey('extension', $arguments);
+    }
+
+    public function testExtensionEnableCommandRequiredArgument()
+    {
+        $definition = $this->command->getDefinition();
+        $extensionArg = $definition->getArgument('extension');
+
+        $this->assertTrue($extensionArg->isRequired());
+        $this->assertEquals('Extension code or name to enable', $extensionArg->getDescription());
+    }
+
+    public function testExtensionEnableCommandArgumentValidation()
+    {
+        $definition = $this->command->getDefinition();
+        $arguments = $definition->getArguments();
+
+        $this->assertCount(1, $arguments);
+        $this->assertArrayHasKey('extension', $arguments);
+    }
+
+    public function testExtensionEnableCommandOptionsCount()
+    {
+        $definition = $this->command->getDefinition();
+        $options = $definition->getOptions();
+
+        // Should have at least opencart-root option plus base options
+        $this->assertGreaterThanOrEqual(1, count($options));
+    }
+
+    public function testExtensionEnableCommandAllArguments()
+    {
+        $definition = $this->command->getDefinition();
+        $options = $definition->getOptions();
+
+        $optionNames = array_keys($options);
+        $this->assertContains('opencart-root', $optionNames);
+    }
+}

--- a/tests/Unit/ExtensionInstallCommandTest.php
+++ b/tests/Unit/ExtensionInstallCommandTest.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace OpenCart\CLI\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use OpenCart\CLI\Commands\Extension\InstallCommand;
+use OpenCart\CLI\Application;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class ExtensionInstallCommandTest extends TestCase
+{
+    private $command;
+    private $application;
+
+    protected function setUp(): void
+    {
+        $this->application = new Application();
+        $this->command = new InstallCommand();
+        $this->command->setApplication($this->application);
+    }
+
+    public function testExtensionInstallCommandName()
+    {
+        $this->assertEquals('extension:install', $this->command->getName());
+    }
+
+    public function testExtensionInstallCommandDescription()
+    {
+        $this->assertEquals('Install an extension', $this->command->getDescription());
+    }
+
+    public function testExtensionInstallCommandArguments()
+    {
+        $definition = $this->command->getDefinition();
+
+        $this->assertTrue($definition->hasArgument('extension'));
+
+        $extensionArg = $definition->getArgument('extension');
+        $this->assertTrue($extensionArg->isRequired());
+    }
+
+    public function testExtensionInstallCommandOptions()
+    {
+        $definition = $this->command->getDefinition();
+
+        $this->assertTrue($definition->hasOption('activate'));
+        $this->assertTrue($definition->hasOption('opencart-root'));
+
+        $activateOption = $definition->getOption('activate');
+        $this->assertEquals('a', $activateOption->getShortcut());
+    }
+
+    public function testExtensionInstallCommandWithoutOpenCart()
+    {
+        $input = new ArrayInput(['extension' => 'test.zip']);
+        $output = new BufferedOutput();
+
+        $result = $this->command->run($input, $output);
+
+        $this->assertEquals(1, $result);
+        $this->assertStringContainsString('OpenCart installation', $output->fetch());
+    }
+
+    public function testExtensionInstallCommandWithInvalidOpenCartRoot()
+    {
+        $input = new ArrayInput([
+            'extension' => 'test.zip',
+            '--opencart-root' => '/nonexistent/path'
+        ]);
+        $output = new BufferedOutput();
+
+        $result = $this->command->run($input, $output);
+
+        $this->assertEquals(1, $result);
+        $this->assertStringContainsString('OpenCart installation', $output->fetch());
+    }
+
+    public function testExtensionInstallCommandWithActivateOption()
+    {
+        $input = new ArrayInput([
+            'extension' => 'test.zip',
+            '--activate' => true
+        ]);
+        $output = new BufferedOutput();
+
+        $result = $this->command->run($input, $output);
+
+        // Should fail due to no OpenCart but test option parsing
+        $this->assertEquals(1, $result);
+    }
+
+    public function testExtensionInstallCommandWithAllOptions()
+    {
+        $input = new ArrayInput([
+            'extension' => 'test.zip',
+            '--activate' => true
+        ]);
+        $output = new BufferedOutput();
+
+        $result = $this->command->run($input, $output);
+
+        // Should fail due to no OpenCart but test all options parsing
+        $this->assertEquals(1, $result);
+    }
+
+    public function testExtensionInstallCommandHelpText()
+    {
+        $help = $this->command->getHelp();
+        $this->assertIsString($help);
+    }
+
+    public function testExtensionInstallCommandDefinition()
+    {
+        $definition = $this->command->getDefinition();
+        $options = $definition->getOptions();
+        $arguments = $definition->getArguments();
+
+        $this->assertArrayHasKey('activate', $options);
+        $this->assertArrayHasKey('opencart-root', $options);
+        $this->assertArrayHasKey('extension', $arguments);
+    }
+
+    public function testExtensionInstallCommandRequiredArgument()
+    {
+        $definition = $this->command->getDefinition();
+        $extensionArg = $definition->getArgument('extension');
+
+        $this->assertTrue($extensionArg->isRequired());
+        $this->assertEquals('Extension file path or identifier', $extensionArg->getDescription());
+    }
+
+    public function testExtensionInstallCommandOptionShortcuts()
+    {
+        $definition = $this->command->getDefinition();
+
+        $activateOption = $definition->getOption('activate');
+        $this->assertEquals('a', $activateOption->getShortcut());
+    }
+
+    public function testExtensionInstallCommandWithNonexistentFile()
+    {
+        // This test would require creating an OpenCart setup
+        // which is complex in a unit test environment
+        $this->assertTrue(true); // Placeholder for now
+    }
+
+    public function testExtensionInstallCommandArgumentValidation()
+    {
+        $definition = $this->command->getDefinition();
+        $arguments = $definition->getArguments();
+
+        $this->assertCount(1, $arguments);
+        $this->assertArrayHasKey('extension', $arguments);
+    }
+
+    public function testExtensionInstallCommandOptionsCount()
+    {
+        $definition = $this->command->getDefinition();
+        $options = $definition->getOptions();
+
+        // Should have at least activate and opencart-root options
+        $this->assertGreaterThanOrEqual(2, count($options));
+    }
+}

--- a/tests/Unit/ExtensionListCommandTest.php
+++ b/tests/Unit/ExtensionListCommandTest.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace OpenCart\CLI\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use OpenCart\CLI\Commands\Extension\ListCommand;
+use OpenCart\CLI\Application;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class ExtensionListCommandTest extends TestCase
+{
+    private $command;
+    private $application;
+
+    protected function setUp(): void
+    {
+        $this->application = new Application();
+        $this->command = new ListCommand();
+        $this->command->setApplication($this->application);
+    }
+
+    public function testExtensionListCommandName()
+    {
+        $this->assertEquals('extension:list', $this->command->getName());
+    }
+
+    public function testExtensionListCommandDescription()
+    {
+        $this->assertEquals('List installed extensions', $this->command->getDescription());
+    }
+
+    public function testExtensionListCommandArguments()
+    {
+        $definition = $this->command->getDefinition();
+
+        $this->assertTrue($definition->hasArgument('type'));
+
+        $typeArg = $definition->getArgument('type');
+        $this->assertFalse($typeArg->isRequired());
+    }
+
+    public function testExtensionListCommandOptions()
+    {
+        $definition = $this->command->getDefinition();
+
+        $this->assertTrue($definition->hasOption('format'));
+        $this->assertTrue($definition->hasOption('opencart-root'));
+
+        $formatOption = $definition->getOption('format');
+        $this->assertEquals('table', $formatOption->getDefault());
+        $this->assertEquals('f', $formatOption->getShortcut());
+    }
+
+    public function testExtensionListCommandWithoutOpenCart()
+    {
+        $input = new ArrayInput([]);
+        $output = new BufferedOutput();
+
+        $result = $this->command->run($input, $output);
+
+        $this->assertEquals(1, $result);
+        $this->assertStringContainsString('OpenCart installation', $output->fetch());
+    }
+
+    public function testExtensionListCommandWithInvalidOpenCartRoot()
+    {
+        $input = new ArrayInput(['--opencart-root' => '/nonexistent/path']);
+        $output = new BufferedOutput();
+
+        $result = $this->command->run($input, $output);
+
+        $this->assertEquals(1, $result);
+        $this->assertStringContainsString('OpenCart installation', $output->fetch());
+    }
+
+    public function testExtensionListCommandWithType()
+    {
+        $input = new ArrayInput(['type' => 'module']);
+        $output = new BufferedOutput();
+
+        $result = $this->command->run($input, $output);
+
+        // Should fail due to no OpenCart but test argument parsing
+        $this->assertEquals(1, $result);
+    }
+
+    public function testExtensionListCommandJsonFormat()
+    {
+        $input = new ArrayInput(['--format' => 'json']);
+        $output = new BufferedOutput();
+
+        $result = $this->command->run($input, $output);
+
+        // Should fail due to no OpenCart but test format option
+        $this->assertEquals(1, $result);
+    }
+
+    public function testExtensionListCommandYamlFormat()
+    {
+        $input = new ArrayInput(['--format' => 'yaml']);
+        $output = new BufferedOutput();
+
+        $result = $this->command->run($input, $output);
+
+        // Should fail due to no OpenCart but test format option
+        $this->assertEquals(1, $result);
+    }
+
+    public function testExtensionListCommandWithTypeAndFormat()
+    {
+        $input = new ArrayInput([
+            'type' => 'payment',
+            '--format' => 'json'
+        ]);
+        $output = new BufferedOutput();
+
+        $result = $this->command->run($input, $output);
+
+        // Should fail due to no OpenCart but test options parsing
+        $this->assertEquals(1, $result);
+    }
+
+    public function testExtensionListCommandHelpText()
+    {
+        $help = $this->command->getHelp();
+        $this->assertIsString($help);
+    }
+
+    public function testExtensionListCommandDefinition()
+    {
+        $definition = $this->command->getDefinition();
+        $options = $definition->getOptions();
+        $arguments = $definition->getArguments();
+
+        $this->assertArrayHasKey('format', $options);
+        $this->assertArrayHasKey('opencart-root', $options);
+        $this->assertArrayHasKey('type', $arguments);
+    }
+
+    public function testExtensionListCommandDefaultValues()
+    {
+        $definition = $this->command->getDefinition();
+
+        $formatOption = $definition->getOption('format');
+        $this->assertEquals('table', $formatOption->getDefault());
+
+        $typeArg = $definition->getArgument('type');
+        $this->assertNull($typeArg->getDefault());
+    }
+
+    public function testExtensionListCommandFormatValidation()
+    {
+        $definition = $this->command->getDefinition();
+
+        $this->assertTrue($definition->hasOption('format'));
+        $this->assertEquals('f', $definition->getOption('format')->getShortcut());
+    }
+
+    public function testExtensionListCommandAllOptions()
+    {
+        $definition = $this->command->getDefinition();
+        $options = $definition->getOptions();
+
+        $optionNames = array_keys($options);
+        $this->assertContains('format', $optionNames);
+        $this->assertContains('opencart-root', $optionNames);
+
+        // Check that we have basic required options
+        $this->assertGreaterThan(1, count($optionNames));
+    }
+}

--- a/tests/Unit/InfoCommandTest.php
+++ b/tests/Unit/InfoCommandTest.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace OpenCart\CLI\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use OpenCart\CLI\Commands\Database\InfoCommand;
+use OpenCart\CLI\Application;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class InfoCommandTest extends TestCase
+{
+    private $command;
+    private $application;
+
+    protected function setUp(): void
+    {
+        $this->application = new Application();
+        $this->command = new InfoCommand();
+        $this->command->setApplication($this->application);
+    }
+
+    public function testInfoCommandName()
+    {
+        $this->assertEquals('db:info', $this->command->getName());
+    }
+
+    public function testInfoCommandDescription()
+    {
+        $this->assertEquals('Display database connection information', $this->command->getDescription());
+    }
+
+    public function testInfoCommandOptions()
+    {
+        $definition = $this->command->getDefinition();
+
+        $this->assertTrue($definition->hasOption('format'));
+        $this->assertTrue($definition->hasOption('opencart-root'));
+
+        $formatOption = $definition->getOption('format');
+        $this->assertEquals('table', $formatOption->getDefault());
+    }
+
+    public function testInfoCommandWithoutOpenCart()
+    {
+        $input = new ArrayInput([]);
+        $output = new BufferedOutput();
+
+        $result = $this->command->run($input, $output);
+
+        $this->assertEquals(1, $result);
+        $this->assertStringContainsString('OpenCart installation', $output->fetch());
+    }
+
+    public function testInfoCommandWithInvalidOpenCartRoot()
+    {
+        $input = new ArrayInput(['--opencart-root' => '/nonexistent/path']);
+        $output = new BufferedOutput();
+
+        $result = $this->command->run($input, $output);
+
+        $this->assertEquals(1, $result);
+        $this->assertStringContainsString('OpenCart installation', $output->fetch());
+    }
+
+    public function testInfoCommandJsonFormat()
+    {
+        $input = new ArrayInput(['--format' => 'json']);
+        $output = new BufferedOutput();
+
+        // This will fail due to no OpenCart but we can test format option
+        $result = $this->command->run($input, $output);
+
+        $this->assertEquals(1, $result);
+    }
+
+    public function testInfoCommandYamlFormat()
+    {
+        $input = new ArrayInput(['--format' => 'yaml']);
+        $output = new BufferedOutput();
+
+        // This will fail due to no OpenCart but we can test format option
+        $result = $this->command->run($input, $output);
+
+        $this->assertEquals(1, $result);
+    }
+
+    public function testInfoCommandTableFormat()
+    {
+        $input = new ArrayInput(['--format' => 'table']);
+        $output = new BufferedOutput();
+
+        // This will fail due to no OpenCart but we can test format option
+        $result = $this->command->run($input, $output);
+
+        $this->assertEquals(1, $result);
+    }
+
+    public function testInfoCommandDefaultFormat()
+    {
+        $definition = $this->command->getDefinition();
+        $formatOption = $definition->getOption('format');
+
+        $this->assertEquals('table', $formatOption->getDefault());
+    }
+
+    public function testInfoCommandFormatValidation()
+    {
+        $definition = $this->command->getDefinition();
+
+        $this->assertTrue($definition->hasOption('format'));
+        $this->assertEquals('f', $definition->getOption('format')->getShortcut());
+    }
+
+    public function testInfoCommandHelpText()
+    {
+        $help = $this->command->getHelp();
+        $this->assertIsString($help);
+    }
+
+    public function testInfoCommandAllOptions()
+    {
+        $definition = $this->command->getDefinition();
+        $options = $definition->getOptions();
+
+        $optionNames = array_keys($options);
+        $this->assertContains('format', $optionNames);
+        $this->assertContains('opencart-root', $optionNames);
+
+        // Check that we have basic required options
+        $this->assertGreaterThan(1, count($optionNames));
+    }
+}

--- a/tests/Unit/ModificationListCommandTest.php
+++ b/tests/Unit/ModificationListCommandTest.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace OpenCart\CLI\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use OpenCart\CLI\Commands\Extension\ModificationListCommand;
+use OpenCart\CLI\Application;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class ModificationListCommandTest extends TestCase
+{
+    private $command;
+    private $application;
+
+    protected function setUp(): void
+    {
+        $this->application = new Application();
+        $this->command = new ModificationListCommand();
+        $this->command->setApplication($this->application);
+    }
+
+    public function testModificationListCommandName()
+    {
+        $this->assertEquals('modification:list', $this->command->getName());
+    }
+
+    public function testModificationListCommandDescription()
+    {
+        $this->assertEquals('List installed modifications', $this->command->getDescription());
+    }
+
+    public function testModificationListCommandOptions()
+    {
+        $definition = $this->command->getDefinition();
+
+        $this->assertTrue($definition->hasOption('format'));
+        $this->assertTrue($definition->hasOption('opencart-root'));
+
+        $formatOption = $definition->getOption('format');
+        $this->assertEquals('table', $formatOption->getDefault());
+        $this->assertEquals('f', $formatOption->getShortcut());
+    }
+
+    public function testModificationListCommandWithoutOpenCart()
+    {
+        $input = new ArrayInput([]);
+        $output = new BufferedOutput();
+
+        $result = $this->command->run($input, $output);
+
+        $this->assertEquals(1, $result);
+        $this->assertStringContainsString('OpenCart installation', $output->fetch());
+    }
+
+    public function testModificationListCommandWithInvalidOpenCartRoot()
+    {
+        $input = new ArrayInput(['--opencart-root' => '/nonexistent/path']);
+        $output = new BufferedOutput();
+
+        $result = $this->command->run($input, $output);
+
+        $this->assertEquals(1, $result);
+        $this->assertStringContainsString('OpenCart installation', $output->fetch());
+    }
+
+    public function testModificationListCommandJsonFormat()
+    {
+        $input = new ArrayInput(['--format' => 'json']);
+        $output = new BufferedOutput();
+
+        $result = $this->command->run($input, $output);
+
+        // Should fail due to no OpenCart but test format option
+        $this->assertEquals(1, $result);
+    }
+
+    public function testModificationListCommandYamlFormat()
+    {
+        $input = new ArrayInput(['--format' => 'yaml']);
+        $output = new BufferedOutput();
+
+        $result = $this->command->run($input, $output);
+
+        // Should fail due to no OpenCart but test format option
+        $this->assertEquals(1, $result);
+    }
+
+    public function testModificationListCommandTableFormat()
+    {
+        $input = new ArrayInput(['--format' => 'table']);
+        $output = new BufferedOutput();
+
+        $result = $this->command->run($input, $output);
+
+        // Should fail due to no OpenCart but test format option
+        $this->assertEquals(1, $result);
+    }
+
+    public function testModificationListCommandHelpText()
+    {
+        $help = $this->command->getHelp();
+        $this->assertIsString($help);
+    }
+
+    public function testModificationListCommandDefinition()
+    {
+        $definition = $this->command->getDefinition();
+        $options = $definition->getOptions();
+
+        $this->assertArrayHasKey('format', $options);
+        $this->assertArrayHasKey('opencart-root', $options);
+    }
+
+    public function testModificationListCommandDefaultValues()
+    {
+        $definition = $this->command->getDefinition();
+
+        $formatOption = $definition->getOption('format');
+        $this->assertEquals('table', $formatOption->getDefault());
+    }
+
+    public function testModificationListCommandFormatValidation()
+    {
+        $definition = $this->command->getDefinition();
+
+        $this->assertTrue($definition->hasOption('format'));
+        $this->assertEquals('f', $definition->getOption('format')->getShortcut());
+    }
+
+    public function testModificationListCommandAllOptions()
+    {
+        $definition = $this->command->getDefinition();
+        $options = $definition->getOptions();
+
+        $optionNames = array_keys($options);
+        $this->assertContains('format', $optionNames);
+        $this->assertContains('opencart-root', $optionNames);
+
+        // Check that we have basic required options
+        $this->assertGreaterThan(1, count($optionNames));
+    }
+}

--- a/tests/Unit/RestoreCommandTest.php
+++ b/tests/Unit/RestoreCommandTest.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace OpenCart\CLI\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use OpenCart\CLI\Commands\Database\RestoreCommand;
+use OpenCart\CLI\Application;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class RestoreCommandTest extends TestCase
+{
+    private $command;
+    private $application;
+
+    protected function setUp(): void
+    {
+        $this->application = new Application();
+        $this->command = new RestoreCommand();
+        $this->command->setApplication($this->application);
+    }
+
+    public function testRestoreCommandName()
+    {
+        $this->assertEquals('db:restore', $this->command->getName());
+    }
+
+    public function testRestoreCommandDescription()
+    {
+        $this->assertEquals('Restore database from backup', $this->command->getDescription());
+    }
+
+    public function testRestoreCommandArguments()
+    {
+        $definition = $this->command->getDefinition();
+
+        $this->assertTrue($definition->hasArgument('filename'));
+
+        $filenameArg = $definition->getArgument('filename');
+        $this->assertTrue($filenameArg->isRequired());
+    }
+
+    public function testRestoreCommandOptions()
+    {
+        $definition = $this->command->getDefinition();
+
+        $this->assertTrue($definition->hasOption('force'));
+        $this->assertTrue($definition->hasOption('ignore-errors'));
+        $this->assertTrue($definition->hasOption('opencart-root'));
+
+        $forceOption = $definition->getOption('force');
+        $this->assertEquals('f', $forceOption->getShortcut());
+
+        $ignoreErrorsOption = $definition->getOption('ignore-errors');
+        $this->assertEquals('i', $ignoreErrorsOption->getShortcut());
+    }
+
+    public function testRestoreCommandWithoutOpenCart()
+    {
+        $input = new ArrayInput(['filename' => 'nonexistent.sql']);
+        $output = new BufferedOutput();
+
+        $result = $this->command->run($input, $output);
+
+        $this->assertEquals(1, $result);
+        $this->assertStringContainsString('OpenCart installation', $output->fetch());
+    }
+
+    public function testRestoreCommandWithInvalidOpenCartRoot()
+    {
+        $input = new ArrayInput([
+            'filename' => 'nonexistent.sql',
+            '--opencart-root' => '/nonexistent/path'
+        ]);
+        $output = new BufferedOutput();
+
+        $result = $this->command->run($input, $output);
+
+        $this->assertEquals(1, $result);
+        $this->assertStringContainsString('OpenCart installation', $output->fetch());
+    }
+
+    public function testRestoreCommandWithNonexistentFile()
+    {
+        // Create a temporary directory structure to simulate OpenCart
+        $tempDir = sys_get_temp_dir() . '/oc-cli-test-' . uniqid();
+        mkdir($tempDir, 0755, true);
+
+        // Create OpenCart indicator files
+        file_put_contents($tempDir . '/config.php', '<?php define("DB_HOSTNAME", "localhost");');
+
+        $input = new ArrayInput([
+            'filename' => '/nonexistent/backup.sql',
+            '--opencart-root' => $tempDir
+        ]);
+        $output = new BufferedOutput();
+
+        $result = $this->command->run($input, $output);
+
+        $this->assertEquals(1, $result);
+        $outputContent = $output->fetch();
+        // Should contain either "not found" or database connection error
+        $this->assertTrue(
+            str_contains($outputContent, 'not found') ||
+            str_contains($outputContent, 'Could not connect to database') ||
+            str_contains($outputContent, 'Database connection')
+        );
+
+        // Cleanup
+        unlink($tempDir . '/config.php');
+        rmdir($tempDir);
+    }
+
+    public function testRestoreCommandWithForceOption()
+    {
+        $input = new ArrayInput([
+            'filename' => 'nonexistent.sql',
+            '--force' => true
+        ]);
+        $output = new BufferedOutput();
+
+        $result = $this->command->run($input, $output);
+
+        // Should fail due to no OpenCart but test option parsing
+        $this->assertEquals(1, $result);
+    }
+
+    public function testRestoreCommandWithIgnoreErrorsOption()
+    {
+        $input = new ArrayInput([
+            'filename' => 'nonexistent.sql',
+            '--ignore-errors' => true
+        ]);
+        $output = new BufferedOutput();
+
+        $result = $this->command->run($input, $output);
+
+        // Should fail due to no OpenCart but test option parsing
+        $this->assertEquals(1, $result);
+    }
+
+    public function testRestoreCommandAllOptions()
+    {
+        $input = new ArrayInput([
+            'filename' => 'test-backup.sql',
+            '--force' => true,
+            '--ignore-errors' => true
+        ]);
+        $output = new BufferedOutput();
+
+        $result = $this->command->run($input, $output);
+
+        // Should fail due to no OpenCart but test all options parsing
+        $this->assertEquals(1, $result);
+    }
+
+    public function testRestoreCommandHelpText()
+    {
+        $help = $this->command->getHelp();
+        $this->assertIsString($help);
+    }
+
+    public function testRestoreCommandDefinition()
+    {
+        $definition = $this->command->getDefinition();
+        $options = $definition->getOptions();
+        $arguments = $definition->getArguments();
+
+        $this->assertArrayHasKey('force', $options);
+        $this->assertArrayHasKey('ignore-errors', $options);
+        $this->assertArrayHasKey('opencart-root', $options);
+        $this->assertArrayHasKey('filename', $arguments);
+    }
+
+    public function testRestoreCommandRequiredArgument()
+    {
+        $definition = $this->command->getDefinition();
+        $filenameArg = $definition->getArgument('filename');
+
+        $this->assertTrue($filenameArg->isRequired());
+        $this->assertEquals('Backup filename to restore from', $filenameArg->getDescription());
+    }
+
+    public function testRestoreCommandOptionShortcuts()
+    {
+        $definition = $this->command->getDefinition();
+
+        $forceOption = $definition->getOption('force');
+        $this->assertEquals('f', $forceOption->getShortcut());
+
+        $ignoreErrorsOption = $definition->getOption('ignore-errors');
+        $this->assertEquals('i', $ignoreErrorsOption->getShortcut());
+    }
+
+    public function testRestoreCommandWithUnreadableFile()
+    {
+        // This test would require creating an unreadable file
+        // which is complex in a unit test environment
+        $this->assertTrue(true); // Placeholder for now
+    }
+}


### PR DESCRIPTION
This pull request adds several new CLI commands to manage OpenCart databases and extensions, and improves database connection handling. The main focus is on expanding the CLI functionality to support database backup/restore and extension management, as well as making the database connection more robust for testing environments.

**New CLI commands for database management:**

- Added `db:info` command to display database connection details, including size, table count, and server version, with support for multiple output formats (`table`, `json`, `yaml`).
- Added `db:backup` command to create database backups, supporting options for compression, specific tables, and custom output directories.
- Added `db:restore` command to restore a database from a backup file (including compressed `.gz` files), with options to force restore and ignore errors.

**New CLI commands for extension management:**

- Added commands to list, install, enable, disable, and list modifications for extensions. The `extension:disable` command disables an extension by removing it from the relevant database table.

**Core improvements:**

- Improved database connection logic in `Command.php` to set connection and read timeouts, preventing hangs during tests and making the connection process more robust.
- Registered all new commands in the application so they are available by default. [[1]](diffhunk://#diff-00ce90757b1e2f4249d3e36b770c52ad59fbc9d6f7148a08d1f2a896fcedb08fR23-R30) [[2]](diffhunk://#diff-00ce90757b1e2f4249d3e36b770c52ad59fbc9d6f7148a08d1f2a896fcedb08fR64-R71)