### PR TITLE
Add GitHub Actions workflow to update Packagist

### DIFF
--- a/.github/workflows/packagist-update.yml
+++ b/.github/workflows/packagist-update.yml
@@ -1,0 +1,16 @@
+name: Update Packagist
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  update-packagist:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Ping Packagist
+      run: |
+        curl -XPOST -H'content-type:application/json' \
+          'https://packagist.org/api/update-package?username=botonakis&apiToken=${{ secrets.PACKAGIST_API_TOKEN }}' \
+          -d'{"repository":{"url":"https://github.com/Custom-Services-Limited/oc-cli"}}'


### PR DESCRIPTION
Introduces a workflow that triggers on pushes to the main branch and pings Packagist to update the package repository using a secure API token.